### PR TITLE
fix: use public env flag and persist firebase auth

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next';
 import './globals.css';
-import { cookies } from 'next/headers';
 import UserMenu from '@/components/UserMenu';
 import { MessageSquareText } from 'lucide-react';
 
@@ -10,10 +9,7 @@ export const metadata: Metadata = {
   manifest: '/manifest.json',
 };
 
-export default async function RootLayout({ children }: { children: React.ReactNode }) {
-  const cookieStore = await cookies();
-  const userPresent = Boolean(cookieStore.get('rc-auth')?.value);
-
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body className="bg-neutral-50 overflow-hidden antialiased text-neutral-900">
@@ -23,7 +19,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
               <MessageSquareText className="size-5 text-primary" />
               <span className="text-base font-semibold tracking-tight">ReactChat</span>
             </div>
-            <UserMenu userPresent={userPresent} />
+            <UserMenu />
           </header>
           <main className="flex h-[calc(100svh-64px)] flex-col bg-background">
             {children}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,22 @@
-import { cookies } from "next/headers";
+"use client";
+
 import ChatRoom from "@/components/ChatRoom";
 import SignInCard from "@/components/SignInCard";
+import { useAuthState } from "react-firebase-hooks/auth";
+import { auth } from "@/lib/firebase";
 
-export default async function Page() {
-  const cookieStore = await cookies();
-  const isAuthed = Boolean(cookieStore.get("rc-auth")?.value);
+export default function Page() {
+  const [user, loading] = useAuthState(auth);
 
-  if (isAuthed) {
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        Loading...
+      </div>
+    );
+  }
+
+  if (user) {
     return <ChatRoom />;
   }
 

--- a/src/components/ChatRoom.tsx
+++ b/src/components/ChatRoom.tsx
@@ -54,7 +54,9 @@ export default function ChatRoom() {
   return (
     <div className="flex h-full flex-col">
         {
-            process.env.FLAG_SHOW_CHATROOM_HEADER === "true" && <ChatroomHeader />
+            process.env.NEXT_PUBLIC_FLAG_SHOW_CHATROOM_HEADER === "true" && (
+                <ChatroomHeader />
+            )
         }
 
       <ScrollArea className="flex-1 px-3 py-4">

--- a/src/components/SignInCard.tsx
+++ b/src/components/SignInCard.tsx
@@ -4,18 +4,14 @@ import { Button } from "@/components/ui/button";
 import { LogIn, MessageSquareText } from "lucide-react";
 import { firebaseSignInWithPopup } from "@/lib/firebase";
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 
 export default function SignInCard() {
   const [loading, setLoading] = useState(false);
-  const router = useRouter();
 
   const signIn = async () => {
     setLoading(true);
     try {
       await firebaseSignInWithPopup();
-      document.cookie = "rc-auth=1; Path=/; SameSite=Lax";
-      router.refresh();
     } finally {
       setLoading(false);
     }

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -11,15 +11,12 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { LogOut } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useAuthState } from "react-firebase-hooks/auth";
 
-export default function UserMenu({ userPresent }: { userPresent: boolean }) {
-  const router = useRouter();
-
+export default function UserMenu() {
   const [user, loading] = useAuthState(auth);
 
-  if (!userPresent) return null;
+  if (loading || !user) return null;
 
   const avatarUrl = user?.photoURL || "https://api.dicebear.com/7.x/identicon/svg?seed=react-chat";
 
@@ -56,8 +53,6 @@ export default function UserMenu({ userPresent }: { userPresent: boolean }) {
         <DropdownMenuItem
           onClick={async () => {
             await firebaseSignOut();
-            document.cookie = "rc-auth=; Max-Age=0; path=/";
-            router.refresh();
           }}
           className="gap-2"
         >


### PR DESCRIPTION
## Summary
- expose `FLAG_SHOW_CHATROOM_HEADER` to clients via `NEXT_PUBLIC_` prefix
- derive auth state from Firebase instead of a session cookie for persistent login

## Testing
- `pnpm build` *(fails: Firebase Error auth/invalid-api-key)*

------
https://chatgpt.com/codex/tasks/task_e_68b70356b714832a89bc0f982b7b50a6